### PR TITLE
Browser back button navigation fix

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -119,7 +119,11 @@ export default function bootstrap ({
   // SYNCHRONIZE iframes with context
   // UPSTREAM
   // updateLocation :: Event -> Effect context
-  const updateLocation = () => context.location.hash = generateHash(id)(getIframes())
+  const updateLocation = () => {
+    const newHash = generateHash(id)(getIframes())
+    // silently changing context hash (replaceState won't trigger 'hashchange' nor adds to history length)
+    return context.history.replaceState(null, '', newHash)
+  }
 
   // bindRouting :: iframe -> subscribe iframe
   const bindRouting = iframe => {


### PR DESCRIPTION
Prevented top window programatic hash change from triggering other events and from adding to history